### PR TITLE
Fix file include on setup install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author_email="mail@eremindmitry.ru, bartlimburg@gmail.com",
     licence="Apache",
     packages=find_packages(),
+    data_files=[("pythonlua",['pythonlua/luainit.lua']), ("",['LICENSE'])],
     package_data={'': ['LICENSE', 'pythonlua/luainit.lua']},
     include_package_data=True,
     long_description="",


### PR DESCRIPTION
Fixes the issue when installing LICENSE and luainit.lua are now included in the setup therefore erroring when trying to transpile